### PR TITLE
build: recovery: Support adding device-specific items

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -686,7 +686,12 @@ recovery_build_prop := $(INSTALLED_BUILD_PROP_TARGET)
 recovery_binary := $(call intermediates-dir-for,EXECUTABLES,recovery)/recovery
 recovery_resources_common := $(call include-path-for, recovery)/res
 recovery_resources_private := $(strip $(wildcard $(TARGET_DEVICE_DIR)/recovery/res))
+ifneq ($(TARGET_RECOVERY_DEVICE_DIRS),)
+recovery_root_private := $(strip \
+    $(foreach d,$(TARGET_RECOVERY_DEVICE_DIRS), $(wildcard $(d)/recovery/root)))
+else
 recovery_root_private := $(strip $(wildcard $(TARGET_DEVICE_DIR)/recovery/root))
+endif
 recovery_resource_deps := $(shell find $(recovery_resources_common) \
   $(recovery_resources_private) $(recovery_root_private) -type f)
 ifneq ($(TARGET_RECOVERY_FSTAB),)


### PR DESCRIPTION
Backported to fix building recovery on some devices such as Xperia Pro (iyokan). Without this patch some files are missing from recovery ramdisk.
