### PR TITLE
Fix dependencies for building droidmedia.

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -530,6 +530,8 @@ subdir_makefiles := \
 ./frameworks/native/cmds/servicemanager/Android.mk \
 ./frameworks/opt/emoji/Android.mk \
 ./frameworks/av/camera/Android.mk \
+./frameworks/av/media/libnbaio/Android.mk \
+./frameworks/av/media/common_time/Android.mk \
 ./frameworks/av/media/libmedia/Android.mk \
 ./frameworks/av/media/libstagefright/Android.mk \
 ./frameworks/av/drm/libdrmframework/Android.mk \


### PR DESCRIPTION
Some additional libraries needed for building droidmedia. These libraries are included also in hybris-12.1 branch.
