### PR TITLE
Search makefiles also from vendor folder.

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -469,7 +469,7 @@ ifneq ($(dont_bother),true)
 # Include all of the makefiles in the system
 #
 
-subdir_makefile_dirs := abi bionic bootable build device external hardware hybris libcore system
+subdir_makefile_dirs := abi bionic bootable build device external hardware hybris libcore system vendor
 
 # Can't use first-makefiles-under here because
 # --mindepth=2 makes the prunes not work.


### PR DESCRIPTION
Some device need libraries provided in vendor folder. At least healthd has been seen needing dependencies from vendor folder.